### PR TITLE
Add basic filter implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
----
+adadadasd asdasd test
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-  - 2.6.4
-before_install: gem install bundler -v 1.17.2
+rvm: 2.6.4
+before_install: gem install bundler
 services:
   - redis-server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flu_shot (0.2.0)
+    flu_shot (0.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler
   flu_shot!
   minitest (~> 5.0)
   mocha (~> 1.11.0)

--- a/flu_shot.gemspec
+++ b/flu_shot.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mocha", "~> 1.11.0"

--- a/lib/flu_shot.rb
+++ b/lib/flu_shot.rb
@@ -11,6 +11,10 @@ module FluShot
     autoload :Redis, 'flu_shot/storage/redis'
   end
 
+  module Pharmacy
+    autoload :Latency, 'flu_shot/pharmacy/latency'
+  end
+
   class Error < StandardError; end
 
   def self.inject(name, params = {}, &block)

--- a/lib/flu_shot.rb
+++ b/lib/flu_shot.rb
@@ -3,6 +3,7 @@ require 'flu_shot/vaccine'
 require 'flu_shot/prescription'
 require 'flu_shot/config'
 require 'flu_shot/sneeze'
+require 'flu_shot/filter'
 
 
 module FluShot
@@ -23,7 +24,12 @@ module FluShot
     end
 
     Prescription.for(name).each do |prescription|
-      Vaccine.find(prescription[:vaccine]).new(prescription[:params].merge(params))
+      klass = Vaccine.find(prescription[:vaccine])
+      if (klass < ::FluShot::Filter)
+        break unless klass.new.check(prescription[:params].merge(params))
+      else
+        klass.new(prescription[:params].merge(params))
+      end
     end
 
     # @test

--- a/lib/flu_shot/filter.rb
+++ b/lib/flu_shot/filter.rb
@@ -1,0 +1,7 @@
+module FluShot
+  class Filter < Vaccine
+    def check(params = {})
+      false
+    end
+  end
+end

--- a/lib/flu_shot/pharmacy/latency.rb
+++ b/lib/flu_shot/pharmacy/latency.rb
@@ -1,0 +1,12 @@
+module FluShot
+  module Pharmacy
+    class Latency < FluShot::Vaccine
+
+      label 'pharmacy.latency'
+
+      def initialize(params = {})
+        sleep (params[:value].to_f / 1000)
+      end
+    end
+  end
+end

--- a/lib/flu_shot/prescription.rb
+++ b/lib/flu_shot/prescription.rb
@@ -15,6 +15,8 @@ module FluShot
       self.class.prescriptions.add(@name, current)
     end
 
+    alias_method :filter, :add
+
     def self.for(name)
       prescriptions.get(name)
     end

--- a/specs/integration/inject_spec.rb
+++ b/specs/integration/inject_spec.rb
@@ -6,10 +6,14 @@ describe :inject do
     label :injection_test_vaccine
 
     def initialize(*args)
-      test(*args)
     end
+  end
 
-    def test(*args)
+  class FilterMock < FluShot::Filter
+    label :filter_mock
+
+    def check(params = {})
+      params[:allow]
     end
   end
 
@@ -18,7 +22,7 @@ describe :inject do
       p.add(:injection_test_vaccine, {})
     end
 
-    Rand123.any_instance.expects(:test).once
+    Rand123.expects(:new).once
     FluShot.inject(:injection_name)
   end
 
@@ -28,7 +32,7 @@ describe :inject do
       p.add(:injection_test_vaccine, {})
     end
 
-    Rand123.any_instance.expects(:test).once
+    Rand123.expects(:new).once
     FluShot.inject(:injection_name)
   end
 
@@ -37,7 +41,28 @@ describe :inject do
       p.add(:injection_test_vaccine, {})
     end
 
-    Rand123.any_instance.expects(:test).with(account: 'account_name').once
+    Rand123.expects(:new).with(account: 'account_name').once
     FluShot.inject(:injection_name, account: 'account_name')
   end
+
+  it 'does not execute the vaccines after a filter returned false on #check' do
+    FluShot::Prescription.spec(:injection_name) do |p|
+      p.filter(:filter_mock, {allow: false})
+      p.add(:vaccine_label, {param: 2})
+    end
+
+    Rand123.expects(:new).with(account: 'account_name').never
+    FluShot.inject(:injection_name, account: 'account_name')
+  end
+
+  it 'does not execute the vaccines after a filter returned false on #check' do
+    FluShot::Prescription.spec(:injection_name) do |p|
+      p.filter(:filter_mock, {allow: true})
+      p.add(:vaccine_label, {param: 2})
+    end
+
+    Rand123.expects(:new).never
+    FluShot.inject(:injection_name, account: 'account_name')
+  end
+
 end

--- a/specs/lib/filter_spec.rb
+++ b/specs/lib/filter_spec.rb
@@ -1,0 +1,19 @@
+module FluShot
+  describe Filter do
+
+    class TestFilter < ::FluShot::Filter
+      label :test_filter
+      def check
+        false
+      end
+    end
+
+    it 'has a label' do
+      assert_equal :test_filter, TestFilter.label
+    end
+
+    it 'has a check method that returns false by default' do
+      refute FluShot::Filter.new.check
+    end
+  end
+end

--- a/specs/lib/pharmacy/latency_spec.rb
+++ b/specs/lib/pharmacy/latency_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe FluShot::Pharmacy::Latency do
+  it 'adds x ms latency using the value parameter' do
+    t = Time.now.to_f
+    FluShot::Pharmacy::Latency.new(value: 1000)
+    assert (Time.now.to_f - t) > 1
+  end
+
+  it 'can be used in a prescription' do
+    FluShot::Prescription.spec(:name) do |p|
+      p.add('pharmacy.latency', {value: 1000})
+    end
+
+    t = Time.now.to_f
+    FluShot.inject(:name)
+    assert (Time.now.to_f - t) > 1
+  end
+end

--- a/specs/lib/prescription_spec.rb
+++ b/specs/lib/prescription_spec.rb
@@ -28,5 +28,13 @@ describe FluShot::Prescription do
       assert_equal({:vaccine => :vaccine_label, :params => {:param => 1}}, FluShot::Prescription.for(:name).first)
       assert_equal 2, FluShot::Prescription.for(:name).size
     end
+
+    it 'can apply filters' do
+      FluShot::Prescription.spec(:name) do |order|
+        order.filter(:vaccine_label)
+      end
+
+      assert_equal({:vaccine => :vaccine_label, :params => {}}, FluShot::Prescription.for(:name).first)
+    end
   end
 end


### PR DESCRIPTION
It adds a very basic filter vaccine that can break out from the prescription execution. In some cases `inject` is being used in middleware where it's quite difficult to execute specific vaccines because it would affect every request. If some attributes are passed, with a filter we could stop the execution of the prescription if conditions don't match. Example:

```
class DomainFilter < FluShot::Filter
  label :domain_filter

  def check(params = {})
    params[:domain] == params[:only_for]
  end
end
```

Now if we add a middleware to Rails
```
class RequestHandler
  def initialize(app)
    @app = app
  end

  def call(env)
    req = Rack::Request.new(env) 
    FluShot.inject('request_handler.before', domain: req.domain)
    @app.call(env)
  end
end
```
then would be good to filter by domain and execute vaccines on certain subdomains only (if you put all your tenants to different subdomains)

So the filter would like the following in the prescription:
```
Prescription.spec('request_handler.before') do |p|
  p.filter(:domain_filter, only_for: 'subdomain.example.com')
  p.add(:latency, value: 2000)
end
```
The execution of the prescription would stop at the filter if the domain of the request is not `subdomain.example.com`.